### PR TITLE
feat: configurable promise resolution pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,16 @@ concurrent asynchronous tasks.
 
 - **defineLayer** – create strongly typed resolvers with input validation.
 - **Include system** – choose fields to include/exclude, with nested selection.
-- **PromiseBatch** – limit concurrency and deduplicate identical requests.
+ - **PromiseBatch** – limit concurrency and deduplicate identical requests.
+ - **createPoolResolver** – configure how arrays of promises are resolved,
+   e.g. limiting concurrency.
 - **Playground** – sample scripts showing usage with a SQLite database via
   Drizzle ORM.
 
 ## Example
 
 ```ts
-import { defineLayer } from "muro";
+import { defineLayer, createPoolResolver } from "muro";
 import { z } from "zod";
 
 const person = defineLayer({
@@ -37,6 +39,8 @@ const book = defineLayer({
     title: "The Great Gatsby",
     author: person.withInput({ id: "1" }),
   }),
+  // Limit resolving nested promises to 4 at a time
+  resolvePromises: createPoolResolver(4),
 });
 
 // Only include the nested author object when requested


### PR DESCRIPTION
## Summary
- allow layers to customize how arrays of promises are resolved
- add createPoolResolver helper to limit concurrent resolutions
- document configurable pool resolver

## Testing
- `bun tsc --noEmit`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_688d7f0338b8832cb2f71b20b3bc4777